### PR TITLE
Remove deprecated distutils

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,45 @@
+import pytest
+
+from yamx.utils import strtobool
+
+
+@pytest.mark.parametrize(
+    "value_to_test, expected",
+    [
+        ("y", 1),
+        ("yes", 1),
+        ("YeS", 1),
+        ("True", 1),
+        ("t", 1),
+        ("1", 1),
+        ("oN", 1),
+        ("false", 0),
+        ("off", 0),
+        ("f", 0),
+        ("n", 0),
+        ("NO", 0),
+        ("0", 0),
+    ],
+)
+def test_strtobool_positive(value_to_test: str, expected: int):
+    actual = strtobool(value_to_test)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "invalid_value",
+    [
+        " 1",
+        "11",
+        "no ",
+        "hello",
+        "!",
+        "",
+        "00",
+        "*",
+        ".",
+    ],
+)
+def test_strtobool_negative(invalid_value: str):
+    with pytest.raises(ValueError, match="invalid truth value"):
+        strtobool(invalid_value)

--- a/yamx/extra.py
+++ b/yamx/extra.py
@@ -1,7 +1,6 @@
 # not very supported pieces of functionality
 
 from dataclasses import dataclass
-from distutils.util import strtobool
 from typing import Any, Dict, Optional, Set
 
 from jinja2 import nodes
@@ -14,6 +13,7 @@ from yamx.containers.data import (
     ConditionalSeq,
 )
 from yamx.loader.utils import get_jinja_env
+from yamx.utils import strtobool
 
 
 @dataclass(frozen=True)

--- a/yamx/utils.py
+++ b/yamx/utils.py
@@ -1,0 +1,14 @@
+def strtobool(val) -> int:
+    """Convert a string representation of truth to true (1) or false (0).
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+    """
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return 1
+    elif val in ("n", "no", "f", "false", "off", "0"):
+        return 0
+    else:
+        raise ValueError("invalid truth value %r" % (val,))


### PR DESCRIPTION
[PEP 632](https://www.python.org/dev/peps/pep-0632/#migration-advice) advises to to reimplement strtobool in code.